### PR TITLE
Fixed options being read from files

### DIFF
--- a/src/System/TaskPipeline/ResourceTree.hs
+++ b/src/System/TaskPipeline/ResourceTree.hs
@@ -411,7 +411,7 @@ resolveDataAccess (PhysicalFileNode layers vf) = do
         logFM DebugS $ logStr $ "Read '" ++ show loc' ++ "'"
         return r)
     return $ case vf ^? vfileEmbeddedValue of
-      Just v  -> layersRes <> v
+      Just v  -> v <> layersRes
       Nothing -> layersRes
   where
     vpath = T.unpack $ toTextRepr $ LTP $ vf ^. vfilePath

--- a/src/System/TaskPipeline/Tasks/Options.hs
+++ b/src/System/TaskPipeline/Tasks/Options.hs
@@ -14,6 +14,7 @@ module System.TaskPipeline.Tasks.Options
 
 import           Prelude                                 hiding (id, (.))
 
+import           Control.Lens
 import           Data.Aeson
 import           Data.DocRecord
 import           Data.DocRecord.OptParse
@@ -37,12 +38,16 @@ getOptions
                              -- docs and default values
   -> PTask m () (DocRec rs)  -- ^ A PTask that returns the new options values,
                              -- overriden by the user
-getOptions path defOpts = arr (const defOpts') >>> accessVirtualFile vfile >>> arr post
+getOptions path defOpts = arr (const $ error "getOptions: THIS IS VOID") >>> accessVirtualFile vfile >>> arr post
   where
     defOpts' = Last $ Just defOpts
     post (Last Nothing)  = defOpts
     post (Last (Just x)) = x
     vfile = bidirVirtualFile path $
+            serials & serialWriters . serialWritersToOutputFile .~ mempty
+            -- We remove all the writers, so if options are read from a file
+            -- this file isn't overwritten
+    serials =
       someBidirSerial (DocRecSerial defOpts' post (Last . Just))
       -- TODO: merge properly the docrecs here instead of just using the last
       -- one


### PR DESCRIPTION
When mapping an option record to a file, the file was overwritten with the default opts. This is fixed