### PR TITLE
Caching and changes in loadData

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -64,6 +64,7 @@ jinko_haskell_library(
             "@hackage//:profunctors",
             "@hackage//:resourcet",
             "@hackage//:retry",
+            "@hackage//:store",
             "@hackage//:streaming",
             "@hackage//:streaming-bytestring",
             "@hackage//:streaming-conduit",

--- a/porcupine-core/examples/Example1.hs
+++ b/porcupine-core/examples/Example1.hs
@@ -47,7 +47,7 @@ computeAnalysis (User name surname _) = Analysis $
 -- having to change it at all.
 analyseOneUser :: (LocationMonad m, KatipContext m) => PTask m () ()
 analyseOneUser =
-  loadLast userFile >>> arr computeAnalysis >>> writeData analysisFile
+  loadData userFile >>> arr computeAnalysis >>> writeData analysisFile
 
 mainTask :: (LocationMonad m, KatipContext m) => PTask m () ()
 mainTask =

--- a/porcupine-core/package.yaml
+++ b/porcupine-core/package.yaml
@@ -43,6 +43,7 @@ dependencies:
   - profunctors
   - resourcet
   - retry
+  - store
   - streaming
   - streaming-bytestring
   - streaming-conduit

--- a/porcupine-core/src/Data/Locations/Loc.hs
+++ b/porcupine-core/src/Data/Locations/Loc.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE StaticPointers       #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wall #-}
 
 module Data.Locations.Loc where
@@ -16,6 +17,7 @@ module Data.Locations.Loc where
 import           Control.Applicative
 import           Control.Lens
 import           Control.Monad              (foldM)
+import           Control.Funflow.ContentHashable
 import           Data.Aeson
 import           Data.Binary                (Binary)
 import qualified Data.HashMap.Strict        as HM
@@ -74,6 +76,8 @@ concatLocBitChunks [] = []
 data LocFilePath a = LocFilePath { _pathWithoutExt :: a, _pathExtension :: String }
   deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary, Store)
 
+instance (Monad m, ContentHashable m a) => ContentHashable m (LocFilePath a)
+
 makeLenses ''LocFilePath
 
 firstNonEmptyExt :: String -> String -> String
@@ -115,7 +119,10 @@ data Loc_ a
      | ParquetObj ...
      | SQLTableObj ...
   -}
-  deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary, Store)
+  deriving ( Eq, Ord, Generic, ToJSON, FromJSON
+           , Functor, Foldable, Traversable, Binary, Store )
+
+instance (Monad m, ContentHashable m a) => ContentHashable m (Loc_ a)
 
 instance (IsLocString a) => Show (Loc_ a) where
   show LocalFile{ filePath } = show filePath

--- a/porcupine-core/src/Data/Locations/Loc.hs
+++ b/porcupine-core/src/Data/Locations/Loc.hs
@@ -165,6 +165,14 @@ spliceLocVariables vars = over locVariables $ \v -> case v of
       Nothing  -> v
   _ -> error "spliceLocVariables: Should not happen"
 
+terminateLocWithVars :: LocWithVars -> Either String Loc
+terminateLocWithVars = traverse terminateLocString
+  where
+    terminateLocString (LocString [LocBitChunk s]) = Right s
+    terminateLocString locString = Left $
+      "Variable(s) " ++ show (locString ^.. locStringVariables)
+      ++ " in '" ++ show locString ++ "' haven't been given a value"
+
 -- | Means that @a@ can represent file paths
 class (Monoid a) => IsLocString a where
   locStringAsRawString :: Iso' a String

--- a/porcupine-core/src/Data/Locations/Loc.hs
+++ b/porcupine-core/src/Data/Locations/Loc.hs
@@ -1,35 +1,35 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveDataTypeable   #-}
-{-# LANGUAGE DeriveFoldable       #-}
-{-# LANGUAGE DeriveFunctor        #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DeriveTraversable    #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE NamedFieldPuns       #-}
-{-# LANGUAGE StaticPointers       #-}
-{-# LANGUAGE TemplateHaskell      #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveFoldable        #-}
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DeriveTraversable     #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE StaticPointers        #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 {-# OPTIONS_GHC -Wall #-}
 
 module Data.Locations.Loc where
 
 import           Control.Applicative
-import           Control.Lens
-import           Control.Monad              (foldM)
 import           Control.Funflow.ContentHashable
+import           Control.Lens
+import           Control.Monad                   (foldM)
 import           Data.Aeson
-import           Data.Binary                (Binary)
-import qualified Data.HashMap.Strict        as HM
+import           Data.Binary                     (Binary)
+import qualified Data.HashMap.Strict             as HM
 import           Data.Locations.LocVariable
 import           Data.Representable
-import           Data.Store (Store)
+import           Data.Store                      (Store)
 import           Data.String
-import qualified Data.Text                  as T
-import           GHC.Generics               (Generic)
-import qualified Network.URL                as URL
-import qualified System.Directory           as Dir (createDirectoryIfMissing)
-import qualified System.FilePath            as Path
+import qualified Data.Text                       as T
+import           GHC.Generics                    (Generic)
+import qualified Network.URL                     as URL
+import qualified System.Directory                as Dir (createDirectoryIfMissing)
+import qualified System.FilePath                 as Path
 
 
 -- | Each location bit can be a simple chunk of string, or a variable name

--- a/porcupine-core/src/Data/Locations/Loc.hs
+++ b/porcupine-core/src/Data/Locations/Loc.hs
@@ -21,6 +21,7 @@ import           Data.Binary                (Binary)
 import qualified Data.HashMap.Strict        as HM
 import           Data.Locations.LocVariable
 import           Data.Representable
+import           Data.Store (Store)
 import           Data.String
 import qualified Data.Text                  as T
 import           GHC.Generics               (Generic)
@@ -34,7 +35,7 @@ import qualified System.FilePath            as Path
 data LocBit
   = LocBitChunk FilePath  -- ^ A raw filepath part, to be used as is
   | LocBitVarRef LocVariable -- ^ A variable name
-  deriving (Eq, Generic, ToJSON, FromJSON)
+  deriving (Eq, Generic, ToJSON, FromJSON, Store)
 
 instance Show LocBit where
   show (LocBitChunk s)                = s
@@ -46,6 +47,7 @@ locBitContent f (LocBitVarRef (LocVariable v)) = LocBitVarRef . LocVariable <$> 
 
 -- | A newtype so that we can redefine the Show instance
 newtype LocString = LocString [LocBit]
+  deriving (Generic, Store)
 
 instance Semigroup LocString where
   LocString l1 <> LocString l2 = LocString $ concatLocBitChunks $ l1++l2
@@ -70,7 +72,7 @@ concatLocBitChunks (x : rest) = x : concatLocBitChunks rest
 concatLocBitChunks [] = []
 
 data LocFilePath a = LocFilePath { _pathWithoutExt :: a, _pathExtension :: String }
-  deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary)
+  deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary, Store)
 
 makeLenses ''LocFilePath
 
@@ -113,7 +115,7 @@ data Loc_ a
      | ParquetObj ...
      | SQLTableObj ...
   -}
-  deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary)
+  deriving (Eq, Ord, Generic, ToJSON, FromJSON, Functor, Foldable, Traversable, Binary, Store)
 
 instance (IsLocString a) => Show (Loc_ a) where
   show LocalFile{ filePath } = show filePath

--- a/porcupine-core/src/Data/Locations/LocVariable.hs
+++ b/porcupine-core/src/Data/Locations/LocVariable.hs
@@ -4,10 +4,11 @@ module Data.Locations.LocVariable where
 
 import           Data.Aeson
 import           Data.Hashable (Hashable)
+import           Data.Store    (Store)
 import           Data.String
 
 
 -- | Just a variable name
 newtype LocVariable = LocVariable String
   deriving (IsString, Show, ToJSON, FromJSON, Eq, Hashable
-           ,FromJSONKey, ToJSONKey)
+           ,FromJSONKey, ToJSONKey, Store)

--- a/porcupine-core/src/Data/Locations/LocationMonad.hs
+++ b/porcupine-core/src/Data/Locations/LocationMonad.hs
@@ -39,8 +39,8 @@ import           Network.AWS.S3
 import qualified Network.AWS.S3.TaskPipelineUtils      as S3
 import           Streaming
 import           System.Clock
-import           System.Directory                      (createDirectoryIfMissing
-                                                       ,doesPathExist)
+import           System.Directory                      (createDirectoryIfMissing,
+                                                        doesPathExist)
 import qualified System.FilePath                       as Path
 import qualified System.IO.Temp                        as Tmp
 
@@ -172,7 +172,7 @@ instance MonadBaseControl IO (ResourceT IO) where
 
 instance LocationMonad AWS where
   locExists (LocalFile l) = locExists_Local l
-  locExists _ = return True -- TODO: Implement it
+  locExists _             = return True -- TODO: Implement it
   writeBSS (LocalFile l) = writeBSS_Local l
   writeBSS l             = writeBSS_S3 l
   readBSS (LocalFile l) = readBSS_Local l

--- a/porcupine-core/src/Data/Locations/VirtualFile.hs
+++ b/porcupine-core/src/Data/Locations/VirtualFile.hs
@@ -58,14 +58,14 @@ data VirtualFileReadUsage b where
 -- | A virtual file in the location tree to which we can write @a@ and from
 -- which we can read @b@.
 data VirtualFile a b = VirtualFile
-  { _vfilePath          :: [LocationTreePathItem]
-  , _vfileReadUsage     :: VirtualFileReadUsage b
+  { _vfilePath            :: [LocationTreePathItem]
+  , _vfileReadUsage       :: VirtualFileReadUsage b
   , _vfileMappedByDefault :: Bool
-  , _vfileDocumentation :: Maybe T.Text
-  , _vfileBidirProof    :: Maybe (a :~: b)
+  , _vfileDocumentation   :: Maybe T.Text
+  , _vfileBidirProof      :: Maybe (a :~: b)
                     -- Temporary, necessary until we can do away with docrec
                     -- conversion in the writer part of SerialsFor
-  , _vfileSerials       :: SerialsFor a b }
+  , _vfileSerials         :: SerialsFor a b }
 
 makeLenses ''VirtualFile
 

--- a/porcupine-core/src/Data/Locations/VirtualFile.hs
+++ b/porcupine-core/src/Data/Locations/VirtualFile.hs
@@ -9,17 +9,18 @@ module Data.Locations.VirtualFile
   ( LocationTreePathItem
   , module Data.Locations.SerializationMethod
   , Profunctor(..)
-  , VirtualFile(..), VirtualFileUsage(..)
+  , VirtualFile(..), VirtualFileReadUsage(..)
   , BidirVirtualFile, DataSource, DataSink
   , VirtualFileIntent(..), VirtualFileDescription(..)
   , DocRecOfOptions, RecOfOptions(..)
   , vfileBidirProof, vfileSerials
   , vfileAsBidir, vfileAsBidirE
   , vfileEmbeddedValue, vfileIntermediaryValue, vfileAesonValue
-  , vfilePath, showVFilePath, vfileUsage
+  , vfilePath, showVFilePath, vfileReadUsage
   , dataSource, dataSink, bidirVirtualFile, ensureBidirFile
   , makeSink, makeSource
-  , documentedFile, unusedByDefault
+  , documentedFile
+  , usesLayeredMapping, canBeUnmapped, unmappedByDefault
   , getVirtualFileDescription
   , vfileRecOfOptions
   ) where
@@ -48,17 +49,18 @@ import           Data.Void
 
 -- * The general 'VirtualFile' type
 
--- | Tells whether the file can remain unmapped or not
-data VirtualFileUsage = MustBeMapped
-                      | CanBeUnmapped
-                      | UnmappedByDefault
-  deriving (Eq, Show)
+-- | Tells how the file is meant to be read
+data VirtualFileReadUsage b where
+  SingleMapping          :: VirtualFileReadUsage b
+  LayeredMapping         :: Semigroup b => VirtualFileReadUsage b
+  LayeredMappingWithNull :: Monoid b => VirtualFileReadUsage b
 
 -- | A virtual file in the location tree to which we can write @a@ and from
 -- which we can read @b@.
 data VirtualFile a b = VirtualFile
   { _vfilePath          :: [LocationTreePathItem]
-  , _vfileUsage         :: VirtualFileUsage
+  , _vfileReadUsage     :: VirtualFileReadUsage b
+  , _vfileMappedByDefault :: Bool
   , _vfileDocumentation :: Maybe T.Text
   , _vfileBidirProof    :: Maybe (a :~: b)
                     -- Temporary, necessary until we can do away with docrec
@@ -69,8 +71,8 @@ makeLenses ''VirtualFile
 
 -- How we derive the default configuration for mapping some VirtualFile
 instance HasDefaultMappingRule (VirtualFile a b) where
-  getDefaultLocShortcut vf
-    | vf ^. vfileUsage /= UnmappedByDefault = Just $
+  getDefaultLocShortcut vf = if vf ^. vfileMappedByDefault
+    then Just $
       case vf ^? vfileSerials . serialsRepetitionKeys . filtered (not . null) of
         Nothing -> DeriveWholeLocFromTree defExt
         -- LIMITATION: For now we suppose that every reading/writing function in
@@ -80,7 +82,7 @@ instance HasDefaultMappingRule (VirtualFile a b) where
               ls = LocString $ (LocBitChunk "-")
                    : intersperse (LocBitChunk "-") (map toVar rkeys)
           in LocFilePath ls $ T.unpack defExt
-    | otherwise = Nothing
+    else Nothing
     where
       defExt =
         case vf ^. vfileSerials . serialDefaultExt of
@@ -90,13 +92,14 @@ instance HasDefaultMappingRule (VirtualFile a b) where
 -- For now, given the requirement of PTask, VirtualFile has to be a Monoid
 -- because a Resource Tree also has to.
 instance Semigroup (VirtualFile a b) where
-  VirtualFile p u d b s <> VirtualFile _ _ _ _ s' =
-    VirtualFile p u d b (s<>s')
+  VirtualFile p u m d b s <> VirtualFile _ _ _ _ _ s' =
+    VirtualFile p u m d b (s<>s')
 instance Monoid (VirtualFile a b) where
-  mempty = VirtualFile [] UnmappedByDefault Nothing Nothing mempty
+  mempty = VirtualFile [] SingleMapping True Nothing Nothing mempty
 
 instance Profunctor VirtualFile where
-  dimap f g (VirtualFile p u d _ s) = VirtualFile p u d Nothing $ dimap f g s
+  dimap f g (VirtualFile p _ m d _ s) =
+    VirtualFile p SingleMapping m d Nothing $ dimap f g s
 
 
 -- * Obtaining a description of how the 'VirtualFile' should be used
@@ -152,9 +155,22 @@ getVirtualFileDescription vf =
 showVFilePath :: VirtualFile a b -> String
 showVFilePath = T.unpack . toTextRepr .  LTP . _vfilePath
 
--- | Indicates that the file should be mapped to 'null' by default
-unusedByDefault :: VirtualFile a b -> VirtualFile a b
-unusedByDefault = vfileUsage .~ UnmappedByDefault
+-- | Indicates that the file uses layered mapping
+usesLayeredMapping :: (Semigroup b) => VirtualFile a b -> VirtualFile a b
+usesLayeredMapping =
+  vfileReadUsage .~ LayeredMapping
+
+-- | Indicates that the file uses layered mapping, and additionally can be left
+-- unmapped (ie. mapped to null)
+canBeUnmapped :: (Monoid b) => VirtualFile a b -> VirtualFile a b
+canBeUnmapped =
+  vfileReadUsage .~ LayeredMappingWithNull
+
+-- | Indicates that the file should be mapped to null by default
+unmappedByDefault :: (Monoid b) => VirtualFile a b -> VirtualFile a b
+unmappedByDefault =
+    (vfileReadUsage .~ LayeredMappingWithNull)
+  . (vfileMappedByDefault .~ False)
 
 -- | Gives a documentation to the 'VirtualFile'
 documentedFile :: T.Text -> VirtualFile a b -> VirtualFile a b
@@ -177,17 +193,17 @@ type DataSink a = VirtualFile a ()
 -- the data. You should prefer 'dataSink' and 'dataSource' for clarity when the
 -- file is meant to be readonly or writeonly.
 virtualFile :: [LocationTreePathItem] -> Maybe (a :~: b) -> SerialsFor a b -> VirtualFile a b
-virtualFile path refl sers = VirtualFile path CanBeUnmapped Nothing refl sers
+virtualFile path refl sers = VirtualFile path SingleMapping True Nothing refl sers
 
 -- | Creates a virtual file from its virtual path and ways to deserialize the
 -- data.
 dataSource :: [LocationTreePathItem] -> SerialsFor a b -> DataSource b
-dataSource path = virtualFile path Nothing . eraseSerials
+dataSource path = makeSource . virtualFile path Nothing
 
 -- | Creates a virtual file from its virtual path and ways to serialize the
 -- data.
 dataSink :: [LocationTreePathItem] -> SerialsFor a b -> DataSink a
-dataSink path = virtualFile path Nothing . eraseDeserials
+dataSink path = makeSink . virtualFile path Nothing
 
 -- | Like VirtualFile, except we will embed the proof that @a@ and @b@ are the same
 bidirVirtualFile :: [LocationTreePathItem] -> BidirSerials a -> BidirVirtualFile a
@@ -201,7 +217,8 @@ ensureBidirFile vf = vf{_vfileBidirProof=Just Refl}
 
 makeSink :: VirtualFile a b -> DataSink a
 makeSink vf = vf{_vfileSerials=eraseDeserials $ _vfileSerials vf
-                ,_vfileBidirProof=Nothing}
+                ,_vfileBidirProof=Nothing
+                ,_vfileReadUsage=LayeredMappingWithNull}
 
 makeSource :: VirtualFile a b -> DataSource b
 makeSource vf = vf{_vfileSerials=eraseSerials $ _vfileSerials vf

--- a/porcupine-core/src/Porcupine/Serials.hs
+++ b/porcupine-core/src/Porcupine/Serials.hs
@@ -4,7 +4,8 @@ module Porcupine.Serials
   , BidirVirtualFile, DataSource, DataSink
   , LocationTreePathItem
   , localFile
-  , unusedByDefault, documentedFile
+  , documentedFile
+  , usesLayeredMapping, canBeUnmapped, unmappedByDefault
   , bidirVirtualFile, dataSource, dataSink
   , ensureBidirFile, makeSource, makeSink )
 where

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE Arrows #-}
+
 module System.TaskPipeline.Caching
-  ( cacheWithVirtualFile
+  ( cacheWithVFile
   ) where
 
 import Control.Funflow
+import Control.Monad.Catch
 import Data.Locations.VirtualFile
+import Katip
 import System.TaskPipeline.PTask.Internal
 import System.TaskPipeline.VirtualFileAccess
 
@@ -12,5 +16,12 @@ import System.TaskPipeline.VirtualFileAccess
 -- _outside_ of the store. In this case we use the filepath bound to the
 -- VirtualFile to compute the hash. That means that if the VirtualFile is bound
 -- to something else, the step will be re-executed.
-cacheWithVirtualFile :: Properties a b -> VirtualFile c c' -> (a -> m (b,c)) -> PTask m a (b, c')
-cacheWithVirtualFile props vf f = undefined
+cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable c', Monoid c')
+               => Properties a b
+               -> VirtualFile c c'
+               -> (a -> m (b,c))
+               -> PTask m a (b,c')
+cacheWithVFile props vf f = proc input -> do
+  (locs, accessFn) <- withVFileAccessFunction vf (\l a _ -> return (l,a)) -< ()
+  -- makePTask' props (\_ ->
+  undefined -< ()

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -1,0 +1,16 @@
+module System.TaskPipeline.Caching
+  ( cacheWithVirtualFile
+  ) where
+
+import Control.Funflow
+import Data.Locations.VirtualFile
+import System.TaskPipeline.PTask.Internal
+import System.TaskPipeline.VirtualFileAccess
+
+
+-- | Similar to 'wrap' from 'ArrowFlow', but caches a part of the result
+-- _outside_ of the store. In this case we use the filepath bound to the
+-- VirtualFile to compute the hash. That means that if the VirtualFile is bound
+-- to something else, the step will be re-executed.
+cacheWithVirtualFile :: Properties a b -> VirtualFile c c' -> (a -> m (b,c)) -> PTask m a (b, c')
+cacheWithVirtualFile props vf f = undefined

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -4,7 +4,7 @@ module System.TaskPipeline.Caching
   ( cacheWithVFile
 
   -- * Re-exports
-  
+
   , Properties(..)
   , defaultCacherWithIdent
   , Default(..)

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -38,11 +38,6 @@ cacheWithVFile props inputHashablePart vf action = proc input -> do
   fromVFile <- unsafeLiftToPTask daPerformRead -< accessor
   returnA -< (output, fromVFile)
   where
-    cached (input, _, accessor) = do
-      (outputForStore, outputForVFile) <- action input
-      daPerformWrite accessor outputForVFile
-      return outputForStore
-
     getLocsAndAccessor getAccessor _ = do
       let accessor = getAccessor mempty
       locs <- case daLocsAccessed accessor of
@@ -50,6 +45,11 @@ cacheWithVFile props inputHashablePart vf action = proc input -> do
           "cacheWithVFile (" ++ showVFilePath vf ++ "): " ++ e
         Right r -> return r
       return (map (over traversed T.pack) locs, accessor)
+
+    cached (input,_,accessor) = do
+      (outputForStore, outputForVFile) <- action input
+      daPerformWrite accessor outputForVFile
+      return outputForStore
 
     props' = props { cache = cache'
                    , mdpolicy = updMdw <$> mdpolicy props }

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -11,7 +11,6 @@ module System.TaskPipeline.Caching
   ) where
 
 import           Control.Funflow
-import           Control.Funflow.ContentHashable
 import           Control.Lens                          (over, traversed)
 import           Control.Monad.Catch
 import           Data.Default                          (Default (..))
@@ -19,8 +18,6 @@ import           Data.Locations.Loc
 import           Data.Locations.LogAndErrors
 import           Data.Locations.VirtualFile
 import qualified Data.Text                             as T
-import           Katip
-import qualified Path
 import           System.TaskPipeline.PTask
 import           System.TaskPipeline.ResourceTree
 import           System.TaskPipeline.VirtualFileAccess

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -22,6 +22,6 @@ cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable c', Monoid
                -> (a -> m (b,c))
                -> PTask m a (b,c')
 cacheWithVFile props vf f = proc input -> do
-  (locs, accessFn) <- withVFileAccessFunction vf (\l a _ -> return (l,a)) -< ()
+  accessFn <- withVFileAccessFunction vf (\fn _ -> return $ fn mempty) -< ()
   -- makePTask' props (\_ ->
   undefined -< ()

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -6,6 +6,7 @@ module System.TaskPipeline.Caching
 
 import Control.Funflow
 import Control.Monad.Catch
+import Control.Lens (over, traversed)
 import Data.Locations.Loc
 import Data.Locations.VirtualFile
 import Katip
@@ -14,20 +15,21 @@ import System.TaskPipeline.VirtualFileAccess
 import System.TaskPipeline.ResourceTree
 import Control.Funflow.ContentHashable
 import qualified Path
+import qualified Data.Text as T
 
 
 -- | Similar to 'wrap' from 'ArrowFlow', but caches a part of the result
 -- _outside_ of the store. In this case we use the filepath bound to the
 -- VirtualFile to compute the hash. That means that if the VirtualFile is bound
 -- to something else, the step will be re-executed.
-cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable ignored, Monoid ignored
-                  )
-               => Properties (a',[Loc]) b
-               -> VirtualFile c ignored
+cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c
+                  ,Typeable ignored, Monoid ignored)
+               => Properties (a', [Loc_ T.Text]) b  -- String isn't ContentHashable
                -> (a -> a')
+               -> VirtualFile c ignored
                -> (a -> m (b,c))
                -> PTask m a b
-cacheWithVFile props vf inputHashablePart action = proc input -> do
+cacheWithVFile props inputHashablePart vf action = proc input -> do
   (locs,accessFn) <- withVFileAccessFunction vf getLocsAndAccessFn -< ()
   makePTask' props' mempty cached -< (input,locs,accessFn)
   where
@@ -39,8 +41,10 @@ cacheWithVFile props vf inputHashablePart action = proc input -> do
     getLocsAndAccessFn fn _ = do
       let da = fn mempty
       locs <- getLocsAccessed da
-      return (locs, runDataAccessFn da)
+      return (map (over traversed T.pack) locs, runDataAccessFn da)
 
+    props' = props { cache = cache'
+                   , mdpolicy = updMdw <$> mdpolicy props }
     getH (input,locs,_) = (inputHashablePart input, locs)
     cache' = case cache props of
       NoCache -> NoCache
@@ -48,5 +52,3 @@ cacheWithVFile props vf inputHashablePart action = proc input -> do
         let key' salt = key salt . getH
         in Cache key' sv rv
     updMdw mdWriter = mdWriter . getH
-    props' = props { cache = cache'
-                   , mdpolicy = updMdw <$> mdpolicy props }

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -6,22 +6,47 @@ module System.TaskPipeline.Caching
 
 import Control.Funflow
 import Control.Monad.Catch
+import Data.Locations.Loc
 import Data.Locations.VirtualFile
 import Katip
 import System.TaskPipeline.PTask.Internal
 import System.TaskPipeline.VirtualFileAccess
+import System.TaskPipeline.ResourceTree
+import Control.Funflow.ContentHashable
+import qualified Path
 
 
 -- | Similar to 'wrap' from 'ArrowFlow', but caches a part of the result
 -- _outside_ of the store. In this case we use the filepath bound to the
 -- VirtualFile to compute the hash. That means that if the VirtualFile is bound
 -- to something else, the step will be re-executed.
-cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable c', Monoid c')
-               => Properties a b
-               -> VirtualFile c c'
+cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable ignored, Monoid ignored
+                  )
+               => Properties (a',[Loc]) b
+               -> VirtualFile c ignored
+               -> (a -> a')
                -> (a -> m (b,c))
-               -> PTask m a (b,c')
-cacheWithVFile props vf f = proc input -> do
-  accessFn <- withVFileAccessFunction vf (\fn _ -> return $ fn mempty) -< ()
-  -- makePTask' props (\_ ->
-  undefined -< ()
+               -> PTask m a b
+cacheWithVFile props vf inputHashablePart action = proc input -> do
+  (locs,accessFn) <- withVFileAccessFunction vf getLocsAndAccessFn -< ()
+  makePTask' props' mempty cached -< (input,locs,accessFn)
+  where
+    cached _ (input, _, accessFn) = do
+      (outputForStore, outputForVFile) <- action input
+      accessFn outputForVFile
+      return outputForStore
+
+    getLocsAndAccessFn fn _ = do
+      let da = fn mempty
+      locs <- getLocsAccessed da
+      return (locs, runDataAccessFn da)
+
+    getH (input,locs,_) = (inputHashablePart input, locs)
+    cache' = case cache props of
+      NoCache -> NoCache
+      Cache key sv rv ->
+        let key' salt = key salt . getH
+        in Cache key' sv rv
+    updMdw mdWriter = mdWriter . getH
+    props' = props { cache = cache'
+                   , mdpolicy = updMdw <$> mdpolicy props }

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -32,7 +32,8 @@ cacheWithVFile :: (MonadThrow m, KatipContext m, Typeable c, Typeable c')
                -> (a -> m (b,c))
                -> PTask m a (b,c')
 cacheWithVFile props inputHashablePart vf action = proc input -> do
-  (locs,accessor) <- withVFileAccessFunction vf getLocsAndAccessor -< ()
+  (locs,accessor) <-
+    withVFileAccessFunction [ATWrite, ATRead] vf getLocsAndAccessor -< ()
   output <- unsafeLiftToPTask' props' cached -< (input,locs,accessor)
   fromVFile <- unsafeLiftToPTask daPerformRead -< accessor
   returnA -< (output, fromVFile)

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -2,12 +2,19 @@
 
 module System.TaskPipeline.Caching
   ( cacheWithVFile
+
+  -- * Re-exports
+  
+  , Properties(..)
+  , defaultCacherWithIdent
+  , Default(..)
   ) where
 
 import           Control.Funflow
 import           Control.Funflow.ContentHashable
 import           Control.Lens                          (over, traversed)
 import           Control.Monad.Catch
+import           Data.Default                          (Default (..))
 import           Data.Locations.Loc
 import           Data.Locations.LogAndErrors
 import           Data.Locations.VirtualFile

--- a/porcupine-core/src/System/TaskPipeline/Options.hs
+++ b/porcupine-core/src/System/TaskPipeline/Options.hs
@@ -44,7 +44,7 @@ getOptions
                              -- overriden by the user
 getOptions path defOpts =
       arr (\_ -> S.yield ([] :: [Int], error "getOptions: THIS IS VOID"))
-  >>> accessVirtualFile [] vfile
+  >>> accessVirtualFile (DoRead Refl) [] vfile
   >>> streamHeadTask
   >>> arr post
   where

--- a/porcupine-core/src/System/TaskPipeline/Options.hs
+++ b/porcupine-core/src/System/TaskPipeline/Options.hs
@@ -15,22 +15,19 @@ module System.TaskPipeline.Options
   , docField
   ) where
 
-import           Prelude                               hiding (id, (.))
-
-import           Control.Lens
 import           Data.Aeson
 import           Data.DocRecord
 import           Data.DocRecord.OptParse
 import           Data.Locations.LocationMonad
 import           Data.Locations.SerializationMethod
 import           Data.Locations.VirtualFile
-import           Data.Monoid                           (Last (..))
 import           Data.Typeable
 import           GHC.TypeLits                          (KnownSymbol)
 import           Katip
-import qualified Streaming.Prelude                     as S
 import           System.TaskPipeline.PTask
 import           System.TaskPipeline.VirtualFileAccess
+
+import           Prelude                               hiding (id, (.))
 
 
 -- | Add a set of options (as a DocRec) to the 'LocationTree', in order to
@@ -42,26 +39,9 @@ getOptions
                              -- docs and default values
   -> PTask m () (DocRec rs)  -- ^ A PTask that returns the new options values,
                              -- overriden by the user
-getOptions path defOpts =
-      arr (\_ -> S.yield ([] :: [Int], error "getOptions: THIS IS VOID"))
-  >>> accessVirtualFile (DoRead Refl) [] vfile
-  >>> streamHeadTask
-  >>> arr post
-  where
-    defOpts' = Last $ Just defOpts
-    post (Last Nothing)  = defOpts
-    post (Last (Just x)) = x
-    vfile = canBeUnmapped $
-            bidirVirtualFile path $
-            serials & serialWriters . serialWritersToOutputFile .~ mempty
-            -- We remove all the writers, so if options are read from a file
-            -- this file isn't overwritten
-    serials =
-      someBidirSerial (DocRecSerial defOpts' post (Last . Just))
-      -- TODO: merge properly the docrecs here instead of just using the last
-      -- one
-      <>
-      someBidirSerial JSONSerial
+getOptions path defOpts = loadData $
+  bidirVirtualFile path $
+    someBidirSerial (DocRecSerial defOpts id id) <> someBidirSerial JSONSerial
 
 -- | Just like 'getOptions', but for a single field.
 getOption

--- a/porcupine-core/src/System/TaskPipeline/Options.hs
+++ b/porcupine-core/src/System/TaskPipeline/Options.hs
@@ -51,7 +51,8 @@ getOptions path defOpts =
     defOpts' = Last $ Just defOpts
     post (Last Nothing)  = defOpts
     post (Last (Just x)) = x
-    vfile = bidirVirtualFile path $
+    vfile = canBeUnmapped $
+            bidirVirtualFile path $
             serials & serialWriters . serialWritersToOutputFile .~ mempty
             -- We remove all the writers, so if options are read from a file
             -- this file isn't overwritten

--- a/porcupine-core/src/System/TaskPipeline/Options.hs
+++ b/porcupine-core/src/System/TaskPipeline/Options.hs
@@ -28,6 +28,7 @@ import           Data.Monoid                           (Last (..))
 import           Data.Typeable
 import           GHC.TypeLits                          (KnownSymbol)
 import           Katip
+import qualified Streaming.Prelude                     as S
 import           System.TaskPipeline.PTask
 import           System.TaskPipeline.VirtualFileAccess
 
@@ -41,7 +42,11 @@ getOptions
                              -- docs and default values
   -> PTask m () (DocRec rs)  -- ^ A PTask that returns the new options values,
                              -- overriden by the user
-getOptions path defOpts = arr (const $ error "getOptions: THIS IS VOID") >>> accessVirtualFile vfile >>> arr post
+getOptions path defOpts =
+      arr (\_ -> S.yield ([] :: [Int], error "getOptions: THIS IS VOID"))
+  >>> accessVirtualFile [] vfile
+  >>> streamHeadTask
+  >>> arr post
   where
     defOpts' = Last $ Just defOpts
     post (Last Nothing)  = defOpts

--- a/porcupine-core/src/System/TaskPipeline/PTask/Internal.hs
+++ b/porcupine-core/src/System/TaskPipeline/PTask/Internal.hs
@@ -31,7 +31,6 @@ module System.TaskPipeline.PTask.Internal
   , withRunnableState
   , withRunnableState'
   , execRunnablePTask
-  , toRunnable
   , runnableWithoutReqs
   , withPTaskState
   ) where
@@ -233,12 +232,6 @@ splittedPTask = iso to_ from_
 -- | Permits to apply a function to the state of a 'RunnablePTask' when in runs.
 runnablePTaskState :: Setter' (RunnablePTask m a b) (PTaskState m)
 runnablePTaskState = lens unAppArrow (const AppArrow) . setting local
-
--- | Just a shortcut around 'withRunnableState' when you just need to run an
--- action without accessing the tree.
-toRunnable :: (KatipContext m)
-           => (a -> m b) -> RunnablePTask m a b
-toRunnable = withRunnableState . const
 
 -- | Makes a task from a tree of requirements and a function. The 'Properties'
 -- indicate whether we can cache this task.

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Fold.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Fold.hs
@@ -63,7 +63,7 @@ foldStreamTask (FoldA step start done) =
     runnable =
       id &&&& (pure () >>> runnableStart) >>> loopStep >>> first runnableDone
     loopStep = proc (Pair stream acc) -> do
-      firstElem <- toRunnable S.next -< stream
+      firstElem <- withRunnableState (const S.next) -< stream
       case firstElem of
         Left r -> returnA -< (acc, r)
         Right (a, stream') -> do

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Fold.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Fold.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE TupleSections     #-}
 
 module System.TaskPipeline.Repetition.Fold
-  ( ptaskFold
+  ( module Control.Arrow.FoldA
+  , RepInfo(..)
+  , ptaskFold
   , unsafeGeneralizeM
   , foldlTask
   , foldStreamTask
@@ -25,7 +27,7 @@ import           System.TaskPipeline.Repetition.Internal
 
 -- | Turns a fold in some monad to a fold compatible with 'foldTask'
 unsafeGeneralizeM :: (KatipContext m)
-                  => FoldM m a b -> FoldA (PTask m) a b
+                  => FoldM m a b -> FoldA (PTask m) i a b
 unsafeGeneralizeM (FoldM step start done) =
   FoldA (unsafeLiftToPTask $ \(Pair a x) -> step a x)
         (unsafeLiftToPTask $ const start)
@@ -33,15 +35,13 @@ unsafeGeneralizeM (FoldM step start done) =
 
 -- | Creates a 'FoldA' from a 'PTask'.
 ptaskFold :: (Show idx, Monad m)
-          => RepInfo
-          -> PTask m (x,acc) acc
-          -> acc
-          -> FoldA (PTask m) (idx,x) acc
-ptaskFold ri step initAcc =
-  FoldA (arr onInput >>> makeRepeatable ri step >>> arr snd)
-        (pure initAcc) id
+          => RepInfo  -- ^ How to log the repeated task
+          -> PTask m (acc,input) acc -- ^ The folding task
+          -> FoldA' (PTask m) (idx,input) acc
+ptaskFold ri step =
+  FoldA (arr onInput >>> makeRepeatable ri step >>> arr snd) id id
   where
-    onInput (Pair acc (idx,x)) = (idx,(x,acc))
+    onInput (Pair acc (idx,x)) = (idx,(acc,x))
 
 -- | Consumes a Stream with a 'FoldA' created with 'ptaskFold', 'generalizeA',
 -- 'unsafeGeneralizeM', or a composition of such folds.
@@ -51,8 +51,8 @@ ptaskFold ri step initAcc =
 -- overwritten. See 'makeRepeatable'.
 foldStreamTask
   :: (KatipContext m)
-  => FoldA (PTask m) a b
-  -> PTask m (Stream (Of a) m r) (b, r)
+  => FoldA (PTask m) i a b
+  -> PTask m (i, Stream (Of a) m r) (b, r)
 foldStreamTask (FoldA step start done) =
   (reqs, runnable) ^. from splittedPTask
   where
@@ -61,18 +61,19 @@ foldStreamTask (FoldA step start done) =
     (reqsDone, runnableDone)   = done ^. splittedPTask
     reqs = reqsStart <> reqsStep <> reqsDone
     runnable =
-      id &&&& (pure () >>> runnableStart) >>> loopStep >>> first runnableDone
-    loopStep = proc (Pair stream acc) -> do
+      first runnableStart >>> loopStep >>> first runnableDone
+    loopStep = proc (acc, stream) -> do
       firstElem <- withRunnableState (const S.next) -< stream
       case firstElem of
         Left r -> returnA -< (acc, r)
         Right (a, stream') -> do
           acc' <- runnableStep -< Pair acc a
-          loopStep -< Pair stream' acc'
+          loopStep -< (acc', stream')
 
 -- | Consumes a list with a 'FoldA' over 'PTask'
 foldlTask
   :: (KatipContext m)
-  => FoldA (PTask m) a b
-  -> PTask m [a] b
-foldlTask fld = arr S.each >>> foldStreamTask fld >>> arr fst
+  => FoldA (PTask m) i a b
+  -> PTask m (i,[a]) b
+foldlTask fld = arr (\(i,l) -> (i,S.each l))
+            >>> foldStreamTask fld >>> arr fst

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Internal.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module System.TaskPipeline.Repetition.Internal
   ( RepInfo(..)
   , repIndex
@@ -65,9 +67,11 @@ makeRepeatable (RepInfo repetitionKey mbVerb) =
     ( fmap addKeyToVirtualFile reqTree
     , keepingIndex $ modifyingRuntimeState alterState snd runnable )
   where
-    addKeyToVirtualFile (VirtualFileNode vf) =
-      VirtualFileNode $ vf &
+    addKeyToVirtualFile (VirtualFileNode{..}) =
+      VirtualFileNode
+      {vfnodeFile = vfnodeFile &
         over (vfileSerials.serialsRepetitionKeys) (repetitionKey:)
+      ,..}
     addKeyToVirtualFile emptyNode = emptyNode
 
     alterState (idx,_) =

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Internal.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module System.TaskPipeline.Repetition.Internal
   ( RepInfo(..)

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
@@ -128,7 +128,7 @@ repeatedlyWriteData rkey vf =
 -- changing each time the value associated to a repetition key (so the physical
 -- file will be different each time).
 repeatedlyLoadData
-  :: (LocationMonad m, CanRunPTask m, Typeable b, Monoid b, Show i)
+  :: (LocationMonad m, CanRunPTask m, Typeable b, Show i)
   => LocVariable
   -> VirtualFile ignored b -- ^ A 'DataSource'
   -> OSTask m i (Stream (Of i) m r) b
@@ -140,7 +140,7 @@ repeatedlyLoadData rkey vf =
 -- | Like 'repeatedlyLoadData', except the stream of indices to read is obtained
 -- from a list whose elements can be Shown.
 repeatedlyLoadData'
-  :: (LocationMonad m, CanRunPTask m, Typeable b, Monoid b, Show i)
+  :: (LocationMonad m, CanRunPTask m, Typeable b, Show i)
   => LocVariable
   -> VirtualFile ignore b -- ^ A 'DataSource'
   -> OSTask m i [i] b

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
@@ -117,9 +117,9 @@ mappingOverStream_ k v t =
 -- changing each time the value associated to a repetition key (so the physical
 -- file will be different each time). Returns the result of the input stream.
 repeatedlyWriteData
-  :: (LocationMonad m, CanRunPTask m, Typeable a, Show i)
+  :: (LocationMonad m, CanRunPTask m, Typeable a, Typeable b, Show i)
   => LocVariable
-  -> VirtualFile a ignored -- ^ A 'DataSink'
+  -> VirtualFile a b -- ^ Use as a 'DataSink'
   -> ISTask m i a r
 repeatedlyWriteData rkey vf =
   mappingOverStream_ rkey (Just V1) $ writeData vf
@@ -128,9 +128,9 @@ repeatedlyWriteData rkey vf =
 -- changing each time the value associated to a repetition key (so the physical
 -- file will be different each time).
 repeatedlyLoadData
-  :: (LocationMonad m, CanRunPTask m, Typeable b, Show i)
+  :: (LocationMonad m, CanRunPTask m, Typeable a, Typeable b, Show i)
   => LocVariable
-  -> VirtualFile ignored b -- ^ A 'DataSource'
+  -> VirtualFile a b -- ^ Used as a 'DataSource'
   -> OSTask m i (Stream (Of i) m r) b
 repeatedlyLoadData rkey vf =
   arr (fmap (const ()) . S.map (,()))
@@ -140,9 +140,9 @@ repeatedlyLoadData rkey vf =
 -- | Like 'repeatedlyLoadData', except the stream of indices to read is obtained
 -- from a list whose elements can be Shown.
 repeatedlyLoadData'
-  :: (LocationMonad m, CanRunPTask m, Typeable b, Show i)
+  :: (LocationMonad m, CanRunPTask m, Typeable a, Typeable b, Show i)
   => LocVariable
-  -> VirtualFile ignore b -- ^ A 'DataSource'
+  -> VirtualFile a b -- ^ Used as a 'DataSource'
   -> OSTask m i [i] b
 repeatedlyLoadData' rkey vf =
   arr S.each >>> repeatedlyLoadData rkey vf

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE ViewPatterns        #-}
 {-# OPTIONS_GHC -fno-warn-missing-pattern-synonym-signatures #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 -- | This file describes the ResourceTree API. The ResourceTree is central to
 -- every pipeline that runs. It is aggregated from each subtask composing the
@@ -127,8 +128,8 @@ pattern DataAccessNode l x = MbDataAccessNode l (First (Just (SomeDataAccess x))
 
 
 instance Semigroup VirtualFileNode where
-  MbVirtualFileNode at vf <> MbVirtualFileNode at' vf' =
-    MbVirtualFileNode (at <> at') (vf <> vf')
+  MbVirtualFileNode ats vf <> MbVirtualFileNode ats' vf' =
+    MbVirtualFileNode (ats <> ats') (vf <> vf')
 instance Monoid VirtualFileNode where
   mempty = MbVirtualFileNode [] mempty
 -- TODO: It is dubious that composing DataAccessNodes is really needed in the

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -499,7 +499,7 @@ resolveDataAccess (PhysicalFileNode layers vf) = do
   where
     readScheme = vf ^. vfileLayeredReadScheme
     mbEmbeddedVal = vf ^? vfileEmbeddedValue
-    
+
     vpath = T.unpack $ toTextRepr $ LTP $ vf ^. vfilePath
 
     readers = vf ^. vfileSerials . serialReaders . serialReadersFromInputFile


### PR DESCRIPTION
This PR changes a few things:

- loadData and associated functions no longer require Monoid. Single mapping is now the default, and layered mapping can be reactivated by wrapping a VirtualFile in `canBeUnmapped` for instance.
- accesses no longer necessary run both the write & read part of a VirtualFile. They can be splitted and VirtualFiles are no longer transformed with `makeSource` or `makeSink`. This allows normally the same VirtualFile to be used several times in the same pipeline.
- cacheWithVFile allows to use a "partially" cached function. Part of its result will be in the funflow store, part will be in a VirtualFile
- FoldA is more general, as it takes a new type param "i" that is used to extract the init accumulator