### PR TITLE
Cleaner log and exceptions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,7 +34,7 @@ jinko_haskell_library(
         [
             "@hackage//:base",
             "@hackage//:lens",
-            "@hackage//:exceptions",
+            "@hackage//:safe-exceptions",
             "@hackage//:transformers",
             "@hackage//:transformers-base",
             "@hackage//:mtl",
@@ -66,7 +66,6 @@ jinko_haskell_library(
             "@hackage//:data-default",
             "@hackage//:deepseq",
             "@hackage//:directory",
-            "@hackage//:exceptions",
             "@hackage//:filepath",
             "@hackage//:funflow",
             "@hackage//:formatting",
@@ -110,7 +109,7 @@ jinko_haskell_library(
         [
             "@hackage//:base",
             "@hackage//:mtl",
-            "@hackage//:exceptions",
+            "@hackage//:safe-exceptions",
             "@hackage//:amazonka",
             "@hackage//:amazonka-core",
             "@hackage//:amazonka-s3",

--- a/porcupine-core/package.yaml
+++ b/porcupine-core/package.yaml
@@ -24,7 +24,6 @@ dependencies:
   - deepseq
   - directory
   - docrecords
-  - exceptions
   - filepath
   - formatting
   - foldl

--- a/porcupine-core/src/Data/Locations/Accessors.hs
+++ b/porcupine-core/src/Data/Locations/Accessors.hs
@@ -36,7 +36,6 @@ module Data.Locations.Accessors
 
 import           Control.Lens                      (over, (^.), _1)
 -- import           Control.Funflow.ContentHashable
-import           Control.Monad.Catch
 import           Control.Monad.IO.Unlift
 import           Control.Monad.ReaderSoup
 import           Control.Monad.ReaderSoup.Resource

--- a/porcupine-core/src/Data/Locations/Accessors.hs
+++ b/porcupine-core/src/Data/Locations/Accessors.hs
@@ -56,8 +56,7 @@ import           GHC.TypeLits
 import           Katip
 import qualified System.FilePath                   as Path
 import qualified System.IO.Temp                    as Tmp
-import           System.TaskPipeline.Logger        (defaultLoggerScribeParams,
-                                                    runLogger)
+import           System.TaskPipeline.Logger
 
 
 -- | Creates some Loc type, indexed over a symbol (see ReaderSoup for how that
@@ -168,7 +167,7 @@ type BasePorcupineContexts =
 -- | Use it as the base of the record you give to 'runPipelineTask'. Use '(:&)'
 -- to stack other contexts and LocationAccessors on top of it
 baseContexts topNamespace =
-     #katip    <-- ContextRunner (runLogger topNamespace defaultLoggerScribeParams)
+     #katip    <-- ContextRunner (runLogger topNamespace maxVerbosityLoggerScribeParams)
   :& #resource <-- useResource
   :& RNil
 

--- a/porcupine-core/src/Data/Locations/Accessors.hs
+++ b/porcupine-core/src/Data/Locations/Accessors.hs
@@ -73,9 +73,9 @@ class ( MonadMask m, MonadIO m
 
   writeBSS :: LocOf l -> BSS.ByteString m r -> m r
 
-  readBSS :: LocOf l -> (BSS.ByteString m () -> m b) -> m (Either LM.Error b)
+  readBSS :: LocOf l -> (BSS.ByteString m () -> m b) -> m b
 
-  copy :: LocOf l -> LocOf l -> m (Either LM.Error ())
+  copy :: LocOf l -> LocOf l -> m ()
   copy locFrom locTo = readBSS locFrom (writeBSS locTo)
 
   withLocalBuffer :: (FilePath -> m a) -> LocOf l -> m a
@@ -141,13 +141,12 @@ instance (MonadResource m, MonadMask m) => LocationAccessor m "resource" where
   locExists (L l) = LM.checkLocal "locExists" LM.locExists_Local l
   writeBSS (L l) = LM.checkLocal "writeBSS" LM.writeBSS_Local l
   readBSS (L l) f =
-    LM.checkLocal "readBSS" (\l' -> LM.readBSS_Local l' f {->>= LM.eitherToExn-}) l
+    LM.checkLocal "readBSS" (\l' -> LM.readBSS_Local l' f) l
   withLocalBuffer f (L l) =
     LM.checkLocal "withLocalBuffer" (\l' -> f $ l'^.locFilePathAsRawFilePath) l
   copy (L l1) (L l2) =
     LM.checkLocal "copy" (\file1 ->
       LM.checkLocal "copy (2nd argument)" (LM.copy_Local file1) l2) l1
-    -- >>= LM.eitherToExn
 
 instance FromJSON (LocOf "resource") where
   parseJSON v = do

--- a/porcupine-core/src/Data/Locations/FunflowRemoteCache.hs
+++ b/porcupine-core/src/Data/Locations/FunflowRemoteCache.hs
@@ -8,8 +8,10 @@ module Data.Locations.FunflowRemoteCache
   , LiftCacher(..)
   ) where
 
+import           Control.Exception.Safe
 import           Control.Funflow.ContentHashable (ContentHash, hashToPath)
 import qualified Control.Funflow.RemoteCache     as Remote
+import           Control.Lens
 import           Control.Monad.Trans
 import           Data.Bifunctor                  (first)
 import           Data.Locations.Loc
@@ -24,6 +26,9 @@ hashToFilePath = dropTrailingPathSeparator . toFilePath . hashToPath
 
 newtype LocationCacher = LocationCacher Loc
 
+tryS :: (MonadCatch m) => m a -> m (Either String a)
+tryS = fmap (over _Left (displayException :: SomeException -> String)) . try
+
 instance (LocationMonad m, KatipContext m)
       => Remote.Cacher m LocationCacher where
   push (LocationCacher loc) = Remote.pushAsArchive aliasPath $ \hash body -> do
@@ -32,17 +37,17 @@ instance (LocationMonad m, KatipContext m)
     writeLazyByte (loc </> hashToFilePath hash) body
     pure Remote.PushOK
     where
-      aliasPath from to = first show <$>
-        copy
-          (loc </> hashToFilePath from)
-          (loc </> hashToFilePath to)
+      aliasPath from_ to_ = first show <$> tryS
+        (copy
+          (loc </> hashToFilePath from_)
+          (loc </> hashToFilePath to_))
   pull (LocationCacher loc) = Remote.pullAsArchive $ \hash -> do
     logFM DebugS $ logStr $
       "Remote cacher: Reading from file " ++ show (loc </> hashToFilePath hash)
-    readResult <- readLazyByte (loc </> hashToFilePath hash)
+    readResult <- tryS $ readLazyByte (loc </> hashToFilePath hash)
     pure $ case readResult of
       Right bs -> Remote.PullOK bs
-      Left err -> Remote.PullError (show err)
+      Left err -> Remote.PullError err
 
 locationCacher :: Maybe Loc -> Maybe LocationCacher
 locationCacher = fmap LocationCacher

--- a/porcupine-core/src/Data/Locations/LocationMonad.hs
+++ b/porcupine-core/src/Data/Locations/LocationMonad.hs
@@ -15,10 +15,10 @@
 
 module Data.Locations.LocationMonad where
 
+import           Control.Exception.Safe
 import           Control.Lens
-import           Control.Monad.Catch
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Resource
+import           Control.Monad.Trans.Resource hiding (MonadThrow (..))
 import qualified Data.ByteString.Lazy         as LBS
 import qualified Data.ByteString.Streaming    as BSS
 import           Data.Locations.Loc

--- a/porcupine-core/src/Data/Locations/LogAndErrors.hs
+++ b/porcupine-core/src/Data/Locations/LogAndErrors.hs
@@ -5,16 +5,16 @@
 -- errors
 
 module Data.Locations.LogAndErrors
-  ( module Control.Monad.Catch
+  ( module Control.Exception.Safe
   , KatipContext
   , LogThrow, LogCatch, LogMask
   , TaskRunError(..)
   , throwWithPrefix
   ) where
 
-import           Control.Monad.Catch
-import qualified Data.Text           as T
-import           Katip               hiding (logMsg)
+import           Control.Exception.Safe
+import qualified Data.Text              as T
+import           Katip                  hiding (logMsg)
 
 
 -- | An error when running a pipeline of tasks

--- a/porcupine-core/src/Data/Locations/SerializationMethod.hs
+++ b/porcupine-core/src/Data/Locations/SerializationMethod.hs
@@ -20,7 +20,6 @@
 module Data.Locations.SerializationMethod where
 
 import           Control.Lens
-import           Control.Monad.Catch
 import           Data.Aeson                   as A
 import           Data.DocRecord
 import           Data.DocRecord.OptParse      (RecordUsableWithCLI)

--- a/porcupine-core/src/Data/Locations/VirtualFile.hs
+++ b/porcupine-core/src/Data/Locations/VirtualFile.hs
@@ -8,6 +8,7 @@
 module Data.Locations.VirtualFile
   ( LocationTreePathItem
   , module Data.Locations.SerializationMethod
+  , Void
   , Profunctor(..)
   , VirtualFile(..), LayeredReadScheme(..)
   , BidirVirtualFile, DataSource, DataSink
@@ -18,6 +19,7 @@ module Data.Locations.VirtualFile
   , vfileAsBidir, vfileAsBidirE, vfileImportance
   , vfileEmbeddedValue, vfileIntermediaryValue, vfileAesonValue
   , vfilePath, showVFilePath, vfileLayeredReadScheme
+  , vfileVoided
   , vfiOnReadSuccess, vfiOnWriteSuccess, vfiOnError
   , dataSource, dataSink, bidirVirtualFile, ensureBidirFile
   , makeSink, makeSource
@@ -332,3 +334,11 @@ vfileRecOfOptions f vf = case mbopts of
             Nothing -> error "vfileRecOfOptions: record fields aren't compatible"
             Just r' -> convertBack r'
       in vf & vfileEmbeddedValue .~ newVal
+
+-- | Gives access to a version of the VirtualFile without type params
+vfileVoided :: Lens' (VirtualFile a b) (VirtualFile Void ())
+vfileVoided f (VirtualFile p l m i d b s) =
+  rebuild <$> f (VirtualFile p SingleLayerRead m i d Nothing mempty)
+  where
+    rebuild (VirtualFile p' _ m' i' d' _ _) =
+      VirtualFile p' l m' i' d' b s

--- a/porcupine-core/src/Data/Locations/VirtualFile.hs
+++ b/porcupine-core/src/Data/Locations/VirtualFile.hs
@@ -21,7 +21,7 @@ module Data.Locations.VirtualFile
   , vfileOriginalPath, showVFileOriginalPath
   , vfileLayeredReadScheme
   , vfileVoided
-  , vfiOnReadSuccess, vfiOnWriteSuccess, vfiOnError
+  , vfiReadSuccess, vfiWriteSuccess, vfiError
   , dataSource, dataSink, bidirVirtualFile, ensureBidirFile
   , makeSink, makeSource
   , documentedFile
@@ -67,9 +67,9 @@ data LayeredReadScheme b where
 
 -- | Tells how the accesses to this 'VirtualFile' should be logged
 data VFileImportance = VFileImportance
-  { _vfiOnReadSuccess  :: Severity
-  , _vfiOnWriteSuccess :: Severity
-  , _vfiOnError        :: Severity }
+  { _vfiReadSuccess  :: Severity
+  , _vfiWriteSuccess :: Severity
+  , _vfiError        :: Severity }
 
 makeLenses ''VFileImportance
 

--- a/porcupine-core/src/Data/Locations/VirtualFile.hs
+++ b/porcupine-core/src/Data/Locations/VirtualFile.hs
@@ -18,6 +18,7 @@ module Data.Locations.VirtualFile
   , vfileAsBidir, vfileAsBidirE, vfileImportance
   , vfileEmbeddedValue, vfileIntermediaryValue, vfileAesonValue
   , vfilePath, showVFilePath, vfileLayeredReadScheme
+  , vfiOnReadSuccess, vfiOnWriteSuccess, vfiOnError
   , dataSource, dataSink, bidirVirtualFile, ensureBidirFile
   , makeSink, makeSource
   , documentedFile
@@ -97,9 +98,9 @@ instance HasDefaultMappingRule (VirtualFile a b) where
         -- the serials has the same repetition keys
         Just rkeys -> DeriveLocPrefixFromTree $
           let toVar rkey = LocBitVarRef rkey
-              ls = LocString $ (LocBitChunk "-")
-                   : intersperse (LocBitChunk "-") (map toVar rkeys)
-          in LocFilePath ls $ T.unpack defExt
+              locStr = LocString $ (LocBitChunk "-")
+                       : intersperse (LocBitChunk "-") (map toVar rkeys)
+          in LocFilePath locStr $ T.unpack defExt
     else Nothing
     where
       defExt =

--- a/porcupine-core/src/System/TaskPipeline/CLI.hs
+++ b/porcupine-core/src/System/TaskPipeline/CLI.hs
@@ -172,7 +172,7 @@ pureCliParser progName mcfg configFile defCfg cfgCLIParsing cmds defCmd =
   subparser
   ( command "write-config-template"
     (info
-      (pure (Nothing, defaultLoggerScribeParams, [PostParsingWrite configFile defCfg]))
+      (pure (Nothing, maxVerbosityLoggerScribeParams, [PostParsingWrite configFile defCfg]))
       (progDesc $ "Write a default configuration file in " <> configFile')))
   <|>
   handleOptions progName configFile mcfg defCfg cliOverriding <$>

--- a/porcupine-core/src/System/TaskPipeline/CLI.hs
+++ b/porcupine-core/src/System/TaskPipeline/CLI.hs
@@ -298,7 +298,7 @@ handleOptions progName configFile mbCfg defCfg cliOverriding mbCmd saveOverrides
   let defaultCfg = toJSON defCfg
       (cfgWarnings, cfg) = case mbCfg of
         Just c -> mergeWithDefault [] defaultCfg c
-        Nothing -> ([PostParsingLog NoticeS $ logStr $
+        Nothing -> ([PostParsingLog DebugS $ logStr $
                       configFile' ++ " is not found. Treated as empty."]
                    ,defaultCfg)
       (overrideWarnings, mbScribeParamsAndCfgOverriden) =

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -47,7 +47,7 @@ cacheWithVFile props inputHashablePart vf action = proc input -> do
       let accessor = getAccessor mempty
       locs <- case daLocsAccessed accessor of
         Left e  -> throwWithPrefix $
-          "cacheWithVFile (" ++ showVFilePath vf ++ "): " ++ e
+          "cacheWithVFile (" ++ showVFileOriginalPath vf ++ "): " ++ e
         Right r -> return r
       return (map (over traversed T.pack) locs, accessor)
 

--- a/porcupine-core/src/System/TaskPipeline/Caching.hs
+++ b/porcupine-core/src/System/TaskPipeline/Caching.hs
@@ -15,7 +15,6 @@ module System.TaskPipeline.Caching
 import qualified Control.Exception.Safe                as SE
 import           Control.Funflow
 import           Control.Lens                          (over, traversed)
-import           Control.Monad.Catch
 import           Data.Default                          (Default (..))
 import           Data.Locations.Loc
 import           Data.Locations.LogAndErrors

--- a/porcupine-core/src/System/TaskPipeline/Logger.hs
+++ b/porcupine-core/src/System/TaskPipeline/Logger.hs
@@ -12,7 +12,7 @@ module System.TaskPipeline.Logger
   , runLogger
   ) where
 
-import           Control.Monad.Catch      (MonadMask, bracket)
+import           Control.Exception.Safe
 import           Control.Monad.IO.Class   (MonadIO, liftIO)
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty (encodePrettyToTextBuilder)

--- a/porcupine-core/src/System/TaskPipeline/Logger.hs
+++ b/porcupine-core/src/System/TaskPipeline/Logger.hs
@@ -7,7 +7,7 @@ module System.TaskPipeline.Logger
   , LoggerFormat(..)
   , Severity(..)
   , Verbosity(..)
-  , defaultLoggerScribeParams
+  , maxVerbosityLoggerScribeParams
   , log
   , runLogger
   ) where
@@ -43,9 +43,9 @@ data LoggerScribeParams = LoggerScribeParams
   }
   deriving (Eq, Show)
 
--- | Default LoggerScribeParams shows log message from Debug level, with maximum verbosity.
-defaultLoggerScribeParams :: LoggerScribeParams
-defaultLoggerScribeParams = LoggerScribeParams DebugS V3 PrettyLog
+-- | Show log message from Debug level, with maximum verbosity.
+maxVerbosityLoggerScribeParams :: LoggerScribeParams
+maxVerbosityLoggerScribeParams = LoggerScribeParams DebugS V3 PrettyLog
 
 -- | Starts a logger.
 runLogger

--- a/porcupine-core/src/System/TaskPipeline/PTask.hs
+++ b/porcupine-core/src/System/TaskPipeline/PTask.hs
@@ -123,7 +123,7 @@ ptaskRequirements = splittedPTask . _1
 
 -- | To access and transform all the 'VirtualFiles' used by this 'PTask'. The
 -- parameters of the VirtualFiles will remain hidden, but all the metadata is
--- accessible.
+-- accessible. NOTE: The original path of the files isn't settable.
 ptaskUsedFiles :: Traversal' (PTask m a b) (VirtualFile Void ())
 ptaskUsedFiles = ptaskRequirements . traversed . vfnodeFileVoided
 

--- a/porcupine-core/src/System/TaskPipeline/PTask.hs
+++ b/porcupine-core/src/System/TaskPipeline/PTask.hs
@@ -26,6 +26,7 @@ module System.TaskPipeline.PTask
   , Properties
   , tryPTask, throwPTask, clockPTask
   , unsafeLiftToPTask, unsafeLiftToPTask', unsafeRunIOTask
+  , ptaskUsedFiles
   , ptaskRequirements
   , ptaskRunnable
   , ptaskDataAccessTree
@@ -52,8 +53,8 @@ import           Data.String
 import           Katip
 import           System.Clock
 import           System.TaskPipeline.PTask.Internal
-import           System.TaskPipeline.ResourceTree   (DataAccessNode,
-                                                     VirtualFileNode)
+import           System.TaskPipeline.ResourceTree
+
 
 -- | a tasks that discards its inputs and returns ()
 voidTask :: PTask m a ()
@@ -119,6 +120,12 @@ logTask = unsafeLiftToPTask $ \(sev, s) -> logFM sev $ logStr s
 -- | To access and transform the requirements of the PTask before it runs
 ptaskRequirements :: Lens' (PTask m a b) (LocationTree VirtualFileNode)
 ptaskRequirements = splittedPTask . _1
+
+-- | To access and transform all the 'VirtualFiles' used by this 'PTask'. The
+-- parameters of the VirtualFiles will remain hidden, but all the metadata is
+-- accessible.
+ptaskUsedFiles :: Traversal' (PTask m a b) (VirtualFile Void ())
+ptaskUsedFiles = ptaskRequirements . traversed . vfnodeFileVoided
 
 ptaskRunnable :: Lens (PTask m a b) (PTask m a' b')
                       (RunnablePTask m a b) (RunnablePTask m a' b')

--- a/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
+++ b/porcupine-core/src/System/TaskPipeline/Repetition/Streaming.hs
@@ -19,7 +19,6 @@ import           Control.Category
 import           Control.Lens                            hiding ((:>), (.=))
 import           Control.Monad
 import           Data.Locations
-import           Data.Typeable
 import           Katip
 import           Prelude                                 hiding (id, (.))
 import           Streaming                               (Of (..), Stream)

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -418,9 +418,10 @@ data DataAccessContext = DAC
 instance ToJSON DataAccessContext
 instance ToObject DataAccessContext
 instance LogItem DataAccessContext where
-  payloadKeys V3 _ = AllKeys
-  payloadKeys v _ | v >= V1 = SomeKeys ["locationAccessed"]
-  payloadKeys V0 _ = SomeKeys []
+  payloadKeys v _
+    | v == V3   = AllKeys
+    | v >= V1   = SomeKeys ["locationAccessed"]
+    | otherwise = SomeKeys []
 
 makeDataAccessor
   :: (LocationMonad m, LogMask m)

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -112,6 +112,13 @@ data VirtualFileNode = MbVirtualFileNode [VFNodeAccessType] (Maybe SomeVirtualFi
 pattern VirtualFileNode {vfnodeAccesses, vfnodeFile} =
   MbVirtualFileNode vfnodeAccesses (Just (SomeVirtualFile vfnodeFile))
 
+-- | vfnodeFile is a @Traversal'@ into the VirtualFile contained in a
+-- VirtualFileNode, but hiding it's real read/write types.
+vfnodeFileVoided :: Traversal' VirtualFileNode (VirtualFile Void ())
+vfnodeFileVoided f (VirtualFileNode at vf) =
+  VirtualFileNode at <$> vfileVoided f vf
+vfnodeFileVoided _ vfn = pure vfn
+
 -- | The nodes of the ResourceTree, after mapping each 'VirtualFiles' to
 -- physical locations
 data PhysicalFileNode = MbPhysicalFileNode [LocWithVars] (Maybe SomeVirtualFile)

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -54,9 +54,9 @@
 
 module System.TaskPipeline.ResourceTree where
 
+import           Control.Exception.Safe
 import           Control.Lens                            hiding ((<.>))
 import           Control.Monad
-import           Control.Monad.Catch
 import           Data.Aeson
 import           Data.DocRecord
 import           Data.DocRecord.OptParse

--- a/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
+++ b/porcupine-core/src/System/TaskPipeline/ResourceTree.hs
@@ -513,7 +513,7 @@ resolveDataAccess (PhysicalFileNode layers vf) = do
     readScheme = vf ^. vfileLayeredReadScheme
     mbEmbeddedVal = vf ^? vfileEmbeddedValue
 
-    vpath = T.unpack $ toTextRepr $ LTP $ vf ^. vfilePath
+    vpath = T.unpack $ toTextRepr $ LTP $ vf ^. vfileOriginalPath
 
     readers = vf ^. vfileSerials . serialReaders . serialReadersFromInputFile
     writers = vf ^. vfileSerials . serialWriters . serialWritersToOutputFile

--- a/porcupine-core/src/System/TaskPipeline/Run.hs
+++ b/porcupine-core/src/System/TaskPipeline/Run.hs
@@ -23,7 +23,6 @@ module System.TaskPipeline.Run
   ) where
 
 import           Control.Lens
-import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.ReaderSoup
 import           Control.Monad.ReaderSoup.Katip     ()

--- a/porcupine-core/src/System/TaskPipeline/VirtualFileAccess.hs
+++ b/porcupine-core/src/System/TaskPipeline/VirtualFileAccess.hs
@@ -17,7 +17,6 @@
 module System.TaskPipeline.VirtualFileAccess
   ( -- * Reexports
     module Data.Locations.LogAndErrors
-  , Typeable
 
     -- * High-level API
   , loadData
@@ -44,7 +43,6 @@ module System.TaskPipeline.VirtualFileAccess
 
 import           Prelude                            hiding (id, (.))
 
-import qualified Control.Exception.Safe             as SE
 import           Control.Lens
 import           Control.Monad                      (forM)
 import           Control.Monad.Trans
@@ -95,7 +93,7 @@ tryLoadDataStream :: (Exception e, Show idx, LogCatch m, Typeable a, Typeable b)
                   -> PTask m (Stream (Of idx) m r) (Stream (Of (idx, Either e b)) m r)
 tryLoadDataStream lv vf =
        arr (StreamES . S.map (,error "loadDataStream: THIS IS VOID"))
-  >>> accessVirtualFile' (DoRead SE.try) lv vf
+  >>> accessVirtualFile' (DoRead try) lv vf
   >>> arr streamFromES
 
 -- | Uses only the write part of a 'VirtualFile'. It is therefore considered as

--- a/porcupine-core/src/System/TaskPipeline/VirtualFileAccess.hs
+++ b/porcupine-core/src/System/TaskPipeline/VirtualFileAccess.hs
@@ -259,10 +259,10 @@ withVFileInternalAccessFunction accessesToDo vfile f =
           _ -> err "input or output types don't match"
       _ -> err "no access action is present in the tree"
   where
-    path = init $ vfile ^. vfilePath
-    fname = file (last $ vfile ^. vfilePath) $ VirtualFileNode accessesToDo vfile
+    path = init $ vfile ^. vfileOriginalPath
+    fname = file (last $ vfile ^. vfileOriginalPath) $ VirtualFileNode accessesToDo vfile
     err s = throwWithPrefix $
-      "withVFileInternalAccessFunction (" ++ showVFilePath vfile ++ "): " ++ s
+      "withVFileInternalAccessFunction (" ++ showVFileOriginalPath vfile ++ "): " ++ s
 
 -- | Wraps in a task a function that needs to access some items present in a
 -- subfolder of the 'LocationTree' and mark these accesses as done.

--- a/porcupine-s3/package.yaml
+++ b/porcupine-s3/package.yaml
@@ -12,7 +12,7 @@ ghc-options: -Wall
 dependencies:
   - base
   - mtl
-  - exceptions
+  - safe-exceptions
   - amazonka
   - amazonka-core
   - amazonka-s3

--- a/porcupine-s3/src/Control/Monad/ReaderSoup/AWS.hs
+++ b/porcupine-s3/src/Control/Monad/ReaderSoup/AWS.hs
@@ -13,7 +13,7 @@ module Control.Monad.ReaderSoup.AWS
   , useAWS
   ) where
 
-import           Control.Monad.Catch
+import           Control.Exception.Safe
 import           Control.Monad.Reader
 import           Control.Monad.ReaderSoup
 import           Control.Monad.ReaderSoup.Resource ()

--- a/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
+++ b/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
@@ -19,8 +19,8 @@ module Data.Locations.Accessors.AWS
   , runReadLazyByte_
   ) where
 
+import           Control.Exception.Safe
 import           Control.Lens
-import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.ReaderSoup
 import           Control.Monad.ReaderSoup.AWS

--- a/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
+++ b/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
@@ -75,26 +75,29 @@ readBSS_S3
   :: (MonadAWS m)
   => Loc
   -> (BSS.ByteString m () -> m b)
-  -> m (Either Error b)
-readBSS_S3 obj@S3Obj{ bucketName, objectName } k =
-  mapLeft (Error obj . OtherError . displayException) <$> S3.streamObjInto
-        (fromString bucketName)
-        (fromString $ objectName ^. locFilePathAsRawFilePath)
-        k
+  -> m b
+readBSS_S3 S3Obj{ bucketName, objectName } k = do
+  r <- S3.streamObjInto
+         (fromString bucketName)
+         (fromString $ objectName ^. locFilePathAsRawFilePath)
+         k
+  case r of
+    Left e  -> throw e
+    Right r -> return r
 readBSS_S3 _ _ = undefined
 
 copy_S3
   :: (MonadResource m, MonadAWS m)
   => Loc
   -> Loc
-  -> m (Either Error ())
+  -> m ()
 copy_S3 locFrom@(S3Obj bucket1 obj1) locTo@(S3Obj bucket2 obj2)
   | bucket1 == bucket2 = do
-    _ <- S3.copyObj
-          (fromString bucket1)
-          (fromString $ obj1^.locFilePathAsRawFilePath)
-          (fromString $ obj2^.locFilePathAsRawFilePath)
-    pure (Right ())
+      _ <- S3.copyObj
+             (fromString bucket1)
+             (fromString $ obj1^.locFilePathAsRawFilePath)
+             (fromString $ obj2^.locFilePathAsRawFilePath)
+      return ()
   | otherwise = readBSS_S3 locFrom (writeBSS_S3 locTo)
 copy_S3 _ _ = undefined
 
@@ -126,9 +129,9 @@ runWriteLazyByte
 runWriteLazyByte l bs = selectRun l True $ writeLazyByte l bs
 
 -- | Just a shortcut
-runReadLazyByte :: Loc -> IO (Either Error LBS.ByteString)
+runReadLazyByte :: Loc -> IO LBS.ByteString
 runReadLazyByte l = selectRun l True $ readLazyByte l
 
 -- | Just a shortcut
 runReadLazyByte_ :: Loc -> IO LBS.ByteString
-runReadLazyByte_ l = selectRun l True $ readLazyByte_ l
+runReadLazyByte_ l = selectRun l True $ readLazyByte l

--- a/porcupine-s3/src/Network/AWS/S3/TaskPipelineUtils.hs
+++ b/porcupine-s3/src/Network/AWS/S3/TaskPipelineUtils.hs
@@ -138,7 +138,7 @@ streamObjInto :: (MonadAWS m)
                  => BucketName
                  -> ObjectKey
                  -> (BSS.ByteString m () -> m b)
-                 -> m (Either Error b)
+                 -> m (Either SomeException b)
 streamObjInto srcBuck srcObj f = retry (_svcRetry s3) . try $ do
   let g = getObject srcBuck srcObj
   rs <- send g

--- a/porcupine-s3/src/Network/AWS/S3/TaskPipelineUtils.hs
+++ b/porcupine-s3/src/Network/AWS/S3/TaskPipelineUtils.hs
@@ -21,9 +21,9 @@ module Network.AWS.S3.TaskPipelineUtils
   )
 where
 
+import           Control.Exception.Safe
 import           Control.Lens                 hiding ((:>))
 import           Control.Monad                (when)
-import           Control.Monad.Catch          (catch, try)
 import           Control.Monad.Trans.Resource
 import           Control.Retry                (RetryPolicyM (..), limitRetries,
                                                retrying, rsIterNumber)

--- a/reader-soup/package.yaml
+++ b/reader-soup/package.yaml
@@ -12,7 +12,7 @@ ghc-options: -Wall
 dependencies:
   - base
   - lens
-  - exceptions
+  - safe-exceptions
   - transformers
   - transformers-base
   - mtl

--- a/reader-soup/src/Control/Monad/ReaderSoup.hs
+++ b/reader-soup/src/Control/Monad/ReaderSoup.hs
@@ -55,9 +55,9 @@ module Control.Monad.ReaderSoup
   , fromLabel
   ) where
 
+import           Control.Exception.Safe
 import           Control.Lens                (over)
 import           Control.Monad.Base          (MonadBase)
-import           Control.Monad.Catch
 import           Control.Monad.IO.Unlift
 import           Control.Monad.Morph         (hoist)
 import           Control.Monad.Reader.Class


### PR DESCRIPTION
Uses only `safe-exceptions` and removes special handlers in LocationMonad, so error messages are cleaner and IOExceptions easier to catch.