### PR TITLE
Keeping querystring

### DIFF
--- a/porcupine-http/examples/ExamplePokeAPI.hs
+++ b/porcupine-http/examples/ExamplePokeAPI.hs
@@ -75,7 +75,9 @@ mainTask =
   >>> parMapTask_ (repIndex "pokemonId") analyseOnePokemon
 
 main :: IO ()
-main = runPipelineTask (FullConfig "exampleHTTP" "exampleHTTP.yaml" "exampleHTTP_files")
+main = runPipelineTask (FullConfig "example-pokeapi"
+                                   "porcupine-http/examples/example-pokeapi.yaml"
+                                   "example-pokeapi_files")
                        (  #http <-- useHTTP
                             -- We just add #http on top of the baseContexts.
                        :& baseContexts "")

--- a/porcupine-http/examples/example-pokeapi.yaml
+++ b/porcupine-http/examples/example-pokeapi.yaml
@@ -1,0 +1,10 @@
+variables: {}
+data:
+  Settings:
+    pokemonIds: 1
+  Inputs: {}
+  Outputs: {}
+locations:
+  /Inputs/Pokemon: https://pokeapi.co/api/v2/pokemon/{pokemonId}
+  /: example-pokeapi_files
+  /Outputs/Analysis: _-{pokemonId}.json

--- a/porcupine-http/package.yaml
+++ b/porcupine-http/package.yaml
@@ -32,9 +32,9 @@ library:
   source-dirs: src
 
 executables:
-  exampleHTTP:
+  example-pokeapi:
     source-dirs: examples
-    main: ExampleHTTP.hs
+    main: ExamplePokeAPI.hs
     dependencies:
       - porcupine-core
       - porcupine-http

--- a/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
+++ b/porcupine-s3/src/Data/Locations/Accessors/AWS.hs
@@ -44,7 +44,7 @@ import           System.TaskPipeline.Run
 
 -- | Just a compatiblity overlay for code explicitly dealing with S3 URLs
 pattern S3Obj :: String -> LocFilePath a -> URLLikeLoc a
-pattern S3Obj{bucketName,objectName} = RemoteFile "s3" bucketName Nothing objectName
+pattern S3Obj{bucketName,objectName} = RemoteFile "s3" bucketName Nothing objectName []
 
 -- | Accessing resources on S3
 instance (MonadAWS m, MonadMask m, MonadResource m)


### PR DESCRIPTION
The querystring part was ignored in the HTTP accessor. It is now integrated to the URLLikeLoc, and can contain variables.
This PR also renames the pokeapi example.