### PR TITLE
Nix file for porcupine

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ Workflow:
 ### Global
 
 ```
-$ nix-shell -A shell
+$ nix-shell
 ```
 
 This will open a nix-shell with all the dependencies for all the
@@ -115,4 +115,4 @@ shell = pkgs.haskellPackages.shellFor {
 in
 {
   inherit shell;
-} // (builtins.mapAttrs (x: y: builtins.getAttr x pkgs.haskellPackages) porcupinePackages)
+} // (builtins.mapAttrs (x: _: pkgs.haskellPackages.${x}) porcupinePackages)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,118 @@
+/*
+Workflow:
+
+### Global
+
+```
+$ nix-shell -A shell
+```
+
+This will open a nix-shell with all the dependencies for all the
+porcupine packages. This will also generates the cabal files and
+cabal.project needed for all subproject.
+
+```
+$ cabal new-repl porcupine-s3
+```
+
+will open a ghci with porcupine-s3 in scope.
+
+If you change anything to a dependency, you must reload the cabal
+new-repl!
+
+### Local
+
+```
+# Create a shell with all dependencies for porcupine-s3
+nix-shell -A porcupine-s3.env
+
+cd porcupine-s3
+
+# build the cabal file
+hpack
+
+# start a repl
+cabal new-repl
+```
+
+A few notes:
+
+- You must restart your nix-shell to reload dependencies. For example,
+  if you change something in docrecords when working in the
+  porcupine-http shell, changes in docrecords and porcupine-core will
+  be accounted for on next nix-shell restart
+- Nix caching is based on directory content, so any leftover file
+  (such as the generated .cabal) will invalidate it. This can be
+  extended by source filtering
+*/
+
+let
+  porcupinePackages = {
+    docrecords = ./docrecords;
+    reader-soup = ./reader-soup;
+    porcupine-core = ./porcupine-core;
+    porcupine-s3 = ./porcupine-s3;
+    porcupine-http = ./porcupine-http;
+  };
+
+overlayHaskell = _:pkgs:
+{
+  haskellPackages = (pkgs.haskellPackages.override {
+    overrides = self: super: rec {
+
+      # A few package version override.
+      # Hopefully a future nixpkgs update will make them as default
+      # so they will be in the binary cache.
+      network-bsd = super.network-bsd_2_8_1_0;
+      network = super.network_3_1_0_0;
+      socks = super.socks_0_6_0;
+      connection = super.connection_0_3_0;
+      streaming-conduit = pkgs.haskell.lib.doJailbreak super.streaming-conduit;
+
+      # checks take too long, so they are disabled
+      hedis = pkgs.haskell.lib.dontCheck super.hedis_0_12_5;
+
+      funflow = let
+        funflowRev = "f0e0238aba688637fb6487a7ff4e24f2ae312a1d";
+        funflowSource = pkgs.fetchzip {
+          url = "https://github.com/tweag/funflow/archive/${funflowRev}.tar.gz";
+          sha256 = "0gxws140rk4aqy00zja527nv87bnm2blp8bikmdy4a2wyvyc7agv";
+          };
+        in
+          # Check are failing for funflow, this should be investigated
+          pkgs.haskell.lib.dontCheck (super.callCabal2nix "funflow" "${funflowSource}/funflow" {});
+    };
+    }).extend (pkgs.haskell.lib.packageSourceOverrides porcupinePackages);
+};
+
+# Nixpkgs clone
+pkgs = import ./nixpkgs.nix {
+  config = {
+    allowBroken = true; # for a few packages, such as streaming-conduit
+  };
+
+  overlays = [ overlayHaskell ];
+};
+
+# The final shell
+shell = pkgs.haskellPackages.shellFor {
+  packages = p: [p.docrecords p.reader-soup p.porcupine-core p.porcupine-s3 p.porcupine-http];
+
+  # Generates the cabal and cabal project file
+  shellHook =
+  ''
+    echo "packages:" > cabal.project
+    for i in ${toString (builtins.attrNames porcupinePackages)}
+    do
+      hpack $i
+      echo "    $i" >> cabal.project
+    done
+    '';
+};
+
+# this derivation contains the shell and all the porcupine package in
+# direct access
+in
+{
+  inherit shell;
+} // (builtins.mapAttrs (x: y: builtins.getAttr x pkgs.haskellPackages) porcupinePackages)

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,5 @@
+import (fetchTarball {
+  # nixos unstable from 2019-06-26
+  url = https://github.com/NixOS/nixpkgs/archive/20b993ef2c9e818a636582ade9597f71a485209d.tar.gz;
+  sha256 = "0plb93vw662lwxpfac7karsqkkajwr6xp5pfgij2l67bn1if3xd6";
+})

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./.).shell


### PR DESCRIPTION
This nix files proposes a way to build all porcupine packages or to launch a nix-shell with all the necessary dependencies to run `cabal new-repl`.