### PR TITLE
fix MonadFail failure on GHC 8.8.1

### DIFF
--- a/porcupine-core/src/System/TaskPipeline/Run.hs
+++ b/porcupine-core/src/System/TaskPipeline/Run.hs
@@ -175,7 +175,7 @@ getFunflowOpts = do
     parseIdentity (Just "") = return Nothing
     parseIdentity (Just s) = case reads s of
       [(i,_)] -> return $ Just i
-      _       -> fail $ identityVar ++ " isn't a valid integer"
+      _       -> liftIO . fail $ identityVar ++ " isn't a valid integer"
     warnAboutIdentity var = $(logTM) WarningS $ logStr $
       var ++ " has been given but no " ++ identityVar ++
       " has been provided. Caching will NOT be performed."


### PR DESCRIPTION
In GHC 8.8.1 base 4.13.0.0 `System.TaskPipeline.Run.getFunflowOpts`
fails with `Could not deduce (MonadFail m)`, to fix this the use of
`fail` was lifted to IO.