### PR TITLE
Fix build on NixOS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,10 @@
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 resolver: lts-14.6
 
+nix:
+  packages:
+  - zlib
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #


### PR DESCRIPTION
This is required for the `stack` build to succeed on NixOS.